### PR TITLE
Run RuboCop outside Docker because of 2.5.1-alpine issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ help:
 test:
 	docker-compose down
 	docker-compose -f docker-compose.test.yml up --build --abort-on-container-exit --exit-code-from test
+	rubocop -DS --force-exclusion -c .rubocop.yml -d -E
 
 dockerize:
 	docker-compose up --build

--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -7,3 +7,5 @@ sudo rm /usr/local/bin/docker-compose
 curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
 chmod +x docker-compose
 sudo mv docker-compose /usr/local/bin
+
+gem install rubocop rubocop-rspec


### PR DESCRIPTION
Closes #59 